### PR TITLE
add fmi_import_get_fmi_version_unzipped which does not unzip a fmu

### DIFF
--- a/FMIL/src/Import/include/FMI/fmi_import_context.h
+++ b/FMIL/src/Import/include/FMI/fmi_import_context.h
@@ -25,7 +25,7 @@
 #include <fmilib_config.h>
 #include <JM/jm_callbacks.h>
 #include <FMI2/fmi2_xml_callbacks.h>
-#include <FMI/fmi_version.h> 
+#include <FMI/fmi_version.h>
 #include <FMI1/fmi1_types.h>
 #include <FMI1/fmi1_enums.h>
 #include <FMI2/fmi2_types.h>
@@ -35,20 +35,20 @@
 extern "C" {
 #endif
 
-	
-/** 
+
+/**
 \addtogroup fmi_import FMI import library
 @{
 \addtogroup fmi_import_context Library initialization
-Interaction with an FMU by means of the FMI Library starts with allocation of 
+Interaction with an FMU by means of the FMI Library starts with allocation of
 an ::fmi_import_context_t structure. This is done with a call to fmi_import_allocate_context().
 The next step is detection of FMI standard used in the specific FMU. This is achieved by
 calling fmi_import_get_fmi_version() function. When the standard is known a standard
 specific function for processing model description XML should be called to create an
 opaque FMU structure. This is done by calling either fmi1_import_parse_xml() or fmi2_import_parse_xml().
-With the FMU structure available one can proceed by loading the FMU binary 
-(fmi1_import_create_dllfmu() or fmi2_import_create_dllfmu()). After that 
-the code is able to interact with the FMU by means of the methonds presented 
+With the FMU structure available one can proceed by loading the FMU binary
+(fmi1_import_create_dllfmu() or fmi2_import_create_dllfmu()). After that
+the code is able to interact with the FMU by means of the methonds presented
 in \ref fmi1_import_capi and \ref fmi2_import_capi.
 
 \addtogroup  fmi1_import
@@ -59,7 +59,7 @@ in \ref fmi1_import_capi and \ref fmi2_import_capi.
 @{
 */
 
-/** \brief FMI version independent library context. 
+/** \brief FMI version independent library context.
 	Opaque struct returned from fmi_import_allocate_context()
 */
 typedef struct fmi_xml_context_t fmi_import_context_t ;
@@ -100,6 +100,13 @@ FMILIB_EXPORT void fmi_import_set_configuration( fmi_import_context_t* c, int co
 FMILIB_EXPORT fmi_version_enu_t fmi_import_get_fmi_version( fmi_import_context_t* c, const char* fileName, const char* dirName);
 
 /**
+	\brief use the already unzipped FMU specified by the dirName and parse XML to get FMI standard version.
+	@param c - library context.
+	@param dirName - a directory name where the FMU was already unpacked
+*/
+FMILIB_EXPORT fmi_version_enu_t fmi_import_get_fmi_version_unzipped( fmi_import_context_t* c, const char* dirName);
+
+/**
 	\brief FMU version 1.0 object
 */
 typedef struct fmi1_import_t fmi1_import_t;
@@ -126,7 +133,7 @@ FMILIB_EXPORT fmi1_import_t* fmi1_import_parse_xml( fmi_import_context_t* c, con
 */
 FMILIB_EXPORT fmi2_import_t* fmi2_import_parse_xml( fmi_import_context_t* context, const char* dirPath, fmi2_xml_callbacks_t* xml_callbacks);
 
-/** 
+/**
 @}
 */
 

--- a/FMIL/src/Import/src/FMI/fmi_import_context.c
+++ b/FMIL/src/Import/src/FMI/fmi_import_context.c
@@ -59,3 +59,21 @@ fmi_version_enu_t fmi_import_get_fmi_version( fmi_import_context_t* c, const cha
 	c->callbacks->free(mdpath);
 	return ret;
 }
+
+fmi_version_enu_t fmi_import_get_fmi_version_unzipped(fmi_import_context_t* c, const char* dirName) {
+	fmi_version_enu_t ret = fmi_version_unknown_enu;
+	jm_status_enu_t status;
+	char* mdpath;
+	jm_log_verbose(c->callbacks, MODULE, "Detecting FMI standard version");
+
+	if(!dirName || !*dirName) {
+		jm_log_fatal(c->callbacks, MODULE, "No temporary directory name specified");
+		return fmi_version_unknown_enu;
+	}
+
+	mdpath = fmi_import_get_model_description_path(dirName, c->callbacks);
+	ret = fmi_xml_get_fmi_version(c, mdpath);
+	jm_log_info(c->callbacks, MODULE, "XML specifies FMI standard version %s", fmi_version_to_string(ret));
+	c->callbacks->free(mdpath);
+	return ret;
+}


### PR DESCRIPTION
### Purpose

This PR adds a new function `fmi_import_get_fmi_version_unzipped` to `FMILIB` which does not `unzip` an already opened `fmu`