### PR TITLE
export fmi2 modeldescription API to DLL

### DIFF
--- a/fmi4c/include/fmi4c.h
+++ b/fmi4c/include/fmi4c.h
@@ -138,6 +138,17 @@ FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByValueReference(fmiHandle *fmu
 FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByName(fmiHandle *fmu, fmi2String name);
 FMI4C_DLLAPI const char* fmi2_getVariableName(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableDescription(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2_getFmiVersion(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi2_getAuthor(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelName(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelDescription(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelIdentifier(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getCopyright(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getLicense(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationTool(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getVariableNamingConvention(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi2_getVariableDerivativeIndex(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableQuantity(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableUnit(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableDisplayUnit(fmi2VariableHandle* var);

--- a/fmi4c/src/fmi4c.c
+++ b/fmi4c/src/fmi4c.c
@@ -269,6 +269,7 @@ bool parseModelDescriptionFmi1(fmiHandle *fmu)
 //! @returns True if parsing was successful
 bool parseModelDescriptionFmi2(fmiHandle *fmu)
 {
+    fmu->fmi2.fmiVersion_ = NULL;
     fmu->fmi2.modelName = NULL;
     fmu->fmi2.guid = NULL;
     fmu->fmi2.description = NULL;
@@ -331,6 +332,7 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
     }
 
     //Parse attributes in <fmiModelDescription>
+    parseStringAttributeEzXml(rootElement, "fmiVersion",                &fmu->fmi2.fmiVersion_);
     parseStringAttributeEzXml(rootElement, "modelName",                 &fmu->fmi2.modelName);
     parseStringAttributeEzXml(rootElement, "guid",                      &fmu->fmi2.guid);
     parseStringAttributeEzXml(rootElement, "description",               &fmu->fmi2.description);
@@ -1718,7 +1720,6 @@ bool loadFunctionsFmi2(fmiHandle *fmu, fmi2Type fmuType)
 
     //Load all common functions
     fmu->fmi2.getVersion = (fmi2GetVersion_t)loadDllFunction(dll, "fmi2GetVersion", &ok);
-    fmu->fmi2.getVersion = (fmi2GetVersion_t)loadDllFunction(dll, "fmi2GetVersion", &ok);
     fmu->fmi2.getTypesPlatform = (fmi2GetTypesPlatform_t)loadDllFunction(dll, "fmi2GetTypesPlatform", &ok);
     fmu->fmi2.setDebugLogging = (fmi2SetDebugLogging_t)loadDllFunction(dll, "fmi2SetDebugLogging", &ok);
     fmu->fmi2.instantiate = (fmi2Instantiate_t)loadDllFunction(dll, "fmi2Instantiate", &ok);
@@ -2208,11 +2209,18 @@ const char *fmi2_getTypesPlatform(fmiHandle *fmu)
     return fmu->fmi2.getTypesPlatform();
 }
 
+// this function returns the fmiVersion (e.g) fmiVersion = 2.0
+const char *fmi2_getFmiVersion(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.fmiVersion_;
+}
+
+// this function returns the optional model version from the <fmiModeldescription>
 const char *fmi2_getVersion(fmiHandle *fmu)
 {
     TRACEFUNC
-
-    return fmu->fmi2.getVersion();
+    return fmu->fmi2.version;
 }
 
 fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
@@ -2245,6 +2253,7 @@ bool fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, 
     fmu->fmi2.callbacks.stepFinished = stepFinished;
     fmu->fmi2.callbacks.componentEnvironment = componentEnvironment;
 
+    printf("  FMIVersion:         %s\n", fmu->fmi2.fmiVersion_);
     printf("  instanceName:       %s\n", fmu->instanceName);
     printf("  GUID:               %s\n", fmu->fmi2.guid);
     printf("  unzipped location:  %s\n", fmu->unzippedLocation);
@@ -3009,6 +3018,69 @@ const char *fmi2_getVariableDescription(fmi2VariableHandle *var)
 {
     TRACEFUNC
     return var->description;
+}
+
+int fmi2_getVariableDerivativeIndex(fmi2VariableHandle *var)
+{
+    TRACEFUNC
+    return var->derivative;
+}
+
+const char* fmi2_getAuthor(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.author;
+}
+
+const char* fmi2_getModelName(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.modelName;
+}
+
+const char* fmi2_getModelDescription(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.description;
+}
+
+const char* fmi2_getModelIdentifier(fmiHandle *fmu)
+{
+    TRACEFUNC
+    if (fmu->fmi2.supportsCoSimulation)
+        return fmu->fmi2.cs.modelIdentifier;
+    else
+        return fmu->fmi2.me.modelIdentifier;
+}
+
+const char* fmi2_getCopyright(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.copyright;
+}
+
+const char* fmi2_getLicense(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.license;
+}
+
+const char* fmi2_getGenerationTool(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.generationTool;
+}
+
+const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.generationDateAndTime;
+}
+
+const char* fmi2_getVariableNamingConvention(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.variableNamingConvention;
 }
 
 const char *fmi2_getVariableQuantity(fmi2VariableHandle *var)

--- a/fmi4c/src/fmi4c_private.h
+++ b/fmi4c/src/fmi4c_private.h
@@ -252,6 +252,7 @@ typedef struct {
 } fmi2DataMe_t;
 
 typedef struct {
+    const char* fmiVersion_;
     const char* modelName;
     const char* guid;
     const char* description;


### PR DESCRIPTION
### Purpose

This PR exports `fmi2parseModelDescription` API to `fmi4c dll` which is needed by `OMSimulator`