### PR TITLE
fix parsing canGetAndSetFMUstate

### DIFF
--- a/fmi4c/src/fmi4c.c
+++ b/fmi4c/src/fmi4c.c
@@ -356,8 +356,8 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
         parseBooleanAttributeEzXml(cosimElement, "canRunAsynchronuously",                   &fmu->fmi2.cs.canRunAsynchronuously);
         parseBooleanAttributeEzXml(cosimElement, "canBeInstantiatedOnlyOncePerProcess",     &fmu->fmi2.cs.canBeInstantiatedOnlyOncePerProcess);
         parseBooleanAttributeEzXml(cosimElement, "canNotUseMemoryManagementFunctions",      &fmu->fmi2.cs.canNotUseMemoryManagementFunctions);
-        parseBooleanAttributeEzXml(cosimElement, "canGetAndSetFMUState",                    &fmu->fmi2.cs.canGetAndSetFMUState);
-        parseBooleanAttributeEzXml(cosimElement, "canSerializeFMUState",                    &fmu->fmi2.cs.canSerializeFMUState);
+        parseBooleanAttributeEzXml(cosimElement, "canGetAndSetFMUstate",                    &fmu->fmi2.cs.canGetAndSetFMUState);
+        parseBooleanAttributeEzXml(cosimElement, "canSerializeFMUstate",                    &fmu->fmi2.cs.canSerializeFMUState);
         parseBooleanAttributeEzXml(cosimElement, "providesDirectionalDerivative",           &fmu->fmi2.cs.providesDirectionalDerivative);
     }
 
@@ -369,8 +369,8 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
         parseBooleanAttributeEzXml(modelExchangeElement, "completedIntegratorStepNotNeeded",        &fmu->fmi2.me.completedIntegratorStepNotNeeded);
         parseBooleanAttributeEzXml(modelExchangeElement, "canBeInstantiatedOnlyOncePerProcess",     &fmu->fmi2.me.canBeInstantiatedOnlyOncePerProcess);
         parseBooleanAttributeEzXml(modelExchangeElement, "canNotUseMemoryManagementFunctions",      &fmu->fmi2.me.canNotUseMemoryManagementFunctions);
-        parseBooleanAttributeEzXml(modelExchangeElement, "canGetAndSetFMUState",                    &fmu->fmi2.me.canGetAndSetFMUState);
-        parseBooleanAttributeEzXml(modelExchangeElement, "canSerializeFMUState",                    &fmu->fmi2.me.canSerializeFMUState);
+        parseBooleanAttributeEzXml(modelExchangeElement, "canGetAndSetFMUstate",                    &fmu->fmi2.me.canGetAndSetFMUState);
+        parseBooleanAttributeEzXml(modelExchangeElement, "canSerializeFMUstate",                    &fmu->fmi2.me.canSerializeFMUState);
         parseBooleanAttributeEzXml(modelExchangeElement, "providesDirectionalDerivative",           &fmu->fmi2.me.providesDirectionalDerivative);
     }
 
@@ -3448,7 +3448,7 @@ bool fmi2cs_getNeedsExecutionTool(fmiHandle *fmu)
 bool fmi2me_getNeedsExecutionTool(fmiHandle *fmu)
 {
     TRACEFUNC
-        return fmu->fmi2.me.needsExecutionTool;
+    return fmu->fmi2.me.needsExecutionTool;
 }
 
 bool fmics2GetCanHandleVariableCommunicationStepSize(fmiHandle *fmu)


### PR DESCRIPTION
### Purpose
This PR fixes parsing modeldescription.xml for getting and setting `canGetAndSetFMUstate` and `canSerializeFMUstate`