### PR TITLE
fix zlib cmake to build only static libraries

### DIFF
--- a/fmi4c/CMakeLists.txt
+++ b/fmi4c/CMakeLists.txt
@@ -13,23 +13,23 @@ if (${FMI4C_BUILD_DOCUMENTATION})
     add_subdirectory(doc)
 endif()
 
-if(NOT FMI4C_USE_INCLUDED_ZLIB)
-    find_package(ZLIB MODULE)
-endif()
+# if(NOT FMI4C_USE_INCLUDED_ZLIB)
+#     find_package(ZLIB MODULE)
+# endif()
 # If zlib can not be found in the system, then build local version
-if (NOT ZLIB_FOUND)
-    set(zlib_dir "3rdparty/zlib")
-    message(STATUS "Using included ZLIB: ${zlib_dir}")
-    # Must use position independent code if intend to include static zlib into shared (dll) fmi4c lib
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    # Add bundled sources, (EXCLUDE_FROM_ALL prevents zlib from being installed with fmi4c)
-    add_subdirectory(${zlib_dir} EXCLUDE_FROM_ALL)
-    # We highjack the zlibstatic target from the original build system, but it does not have the include directory properties set, so lets add them here
-    set_target_properties(zlibstatic PROPERTIES
-                                     INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/${zlib_dir};${CMAKE_CURRENT_BINARY_DIR}/${zlib_dir}")
-    # Use alias to match name that find-module uses
-    add_library(ZLIB::ZLIB ALIAS zlibstatic)
-endif()
+# if (NOT ZLIB_FOUND)
+#     set(zlib_dir "3rdparty/zlib")
+#     message(STATUS "Using included ZLIB: ${zlib_dir}")
+#     # Must use position independent code if intend to include static zlib into shared (dll) fmi4c lib
+#     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+#     # Add bundled sources, (EXCLUDE_FROM_ALL prevents zlib from being installed with fmi4c)
+#     add_subdirectory(${zlib_dir} EXCLUDE_FROM_ALL)
+#     # We highjack the zlibstatic target from the original build system, but it does not have the include directory properties set, so lets add them here
+#     set_target_properties(zlibstatic PROPERTIES
+#                                      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/${zlib_dir};${CMAKE_CURRENT_BINARY_DIR}/${zlib_dir}")
+#     # Use alias to match name that find-module uses
+#     add_library(ZLIB::ZLIB ALIAS zlibstatic)
+# endif()
 
 set(SRCFILES
     src/fmi4c.c
@@ -79,7 +79,7 @@ target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRE
 target_include_directories(${target_name} PRIVATE src)
 
 # Internal dependecy (PRIVATE) on zlib and ${CMAKE_DL_LIBS}) for libdl on Linux
-target_link_libraries(${target_name} PRIVATE ZLIB::ZLIB ${CMAKE_DL_LIBS})
+# target_link_libraries(${target_name} PRIVATE ZLIB::ZLIB ${CMAKE_DL_LIBS})
 
 install(TARGETS ${target_name}
         RUNTIME DESTINATION bin
@@ -89,13 +89,13 @@ install(DIRECTORY include
         DESTINATION .)
 install(DIRECTORY 3rdparty/fmi
         DESTINATION include)
-# If building a static library, also include the local static zlib if it was built
-if (NOT FMI4C_BUILD_SHARED AND TARGET zlibstatic)
-    install(TARGETS zlibstatic
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib)
-endif()
+# # If building a static library, also include the local static zlib if it was built
+# if (NOT FMI4C_BUILD_SHARED AND TARGET zlibstatic)
+#     install(TARGETS zlibstatic
+#             RUNTIME DESTINATION bin
+#             LIBRARY DESTINATION lib
+#             ARCHIVE DESTINATION lib)
+# endif()
 
 if (${FMI4C_BUILD_TEST})
   enable_testing()

--- a/zlib/CMakeLists.txt
+++ b/zlib/CMakeLists.txt
@@ -147,67 +147,15 @@ if(MINGW)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
 endif(MINGW)
 
-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
-set_target_properties(zlib PROPERTIES SOVERSION 1)
 
-if(NOT CYGWIN)
-    # This property causes shared libraries on Linux to have the full version
-    # encoded into their final filename.  We disable this on Cygwin because
-    # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
-    # seems to be the default.
-    #
-    # This has no effect with MSVC, on that platform the version info for
-    # the DLL comes from the resource file win32/zlib1.rc
-    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
-endif()
+set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME zlibstatic)
+    install(TARGETS zlibstatic
+            RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+            ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+            LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
 
-if(UNIX)
-    # On unix-like platforms the library is almost always called libz
-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   if(NOT APPLE)
-     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
-   endif()
-elseif(BUILD_SHARED_LIBS AND WIN32)
-    # Creates zlib1.dll when building shared library version
-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
-endif()
+install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
 
-if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
-    install(TARGETS zlib zlibstatic
-        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
-        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
-        LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
-endif()
-if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
-    install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
-endif()
-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
-    install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")
-endif()
-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
-    install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
-endif()
-
-#============================================================================
-# Example binaries
-#============================================================================
-
-add_executable(example test/example.c)
-target_link_libraries(example zlib)
-add_test(example example)
-
-add_executable(minigzip test/minigzip.c)
-target_link_libraries(minigzip zlib)
-
-if(HAVE_OFF64_T)
-    add_executable(example64 test/example.c)
-    target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
-
-    add_executable(minigzip64 test/minigzip.c)
-    target_link_libraries(minigzip64 zlib)
-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-endif()


### PR DESCRIPTION
### Purpose

This PR fixes the zlib cmake to build only static library