### PR TITLE
link fmi4c library to OMSimulator

### DIFF
--- a/fmi4c/CMakeLists.txt
+++ b/fmi4c/CMakeLists.txt
@@ -47,15 +47,15 @@ set(SRCFILES
     include/fmi4c_functions_fmi1.h
     include/fmi4c_functions_fmi2.h
     include/fmi4c_functions_fmi3.h
-    3rdparty/minizip/miniunz.c
-    3rdparty/minizip/ioapi.c
-    3rdparty/minizip/mztools.c
-    3rdparty/minizip/unzip.c
+    # 3rdparty/minizip/miniunz.c
+    # 3rdparty/minizip/ioapi.c
+    # 3rdparty/minizip/mztools.c
+    # 3rdparty/minizip/unzip.c
     3rdparty/ezxml/ezxml.c
     3rdparty/ezxml/ezxml.h)
-if (WIN32)
-    SET(SRCFILES ${SRCFILES} 3rdparty/minizip/iowin32.c)
-endif()
+# if (WIN32)
+#     SET(SRCFILES ${SRCFILES} 3rdparty/minizip/iowin32.c)
+# endif()
 
 if (FMI4C_BUILD_SHARED)
     add_library(${target_name} SHARED ${SRCFILES})
@@ -77,6 +77,8 @@ endif()
 target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)
 target_include_directories(${target_name} PRIVATE src)
+target_include_directories(${target_name} PUBLIC ${OMS_MINIZIP_INCLUDE_DIR})
+target_link_libraries(${target_name} PUBLIC ${OMS_MINIZIP_LIBRARY})
 target_include_directories(${target_name} PUBLIC ${OMS_ZLIB_INCLUDE_DIR})
 target_link_libraries(${target_name} PUBLIC ${OMS_ZLIB_LIBRARY})
 

--- a/fmi4c/CMakeLists.txt
+++ b/fmi4c/CMakeLists.txt
@@ -77,6 +77,8 @@ endif()
 target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)
 target_include_directories(${target_name} PRIVATE src)
+target_include_directories(${target_name} PUBLIC ${OMS_ZLIB_INCLUDE_DIR})
+target_link_libraries(${target_name} PUBLIC ${OMS_ZLIB_LIBRARY})
 
 # Internal dependecy (PRIVATE) on zlib and ${CMAKE_DL_LIBS}) for libdl on Linux
 # target_link_libraries(${target_name} PRIVATE ZLIB::ZLIB ${CMAKE_DL_LIBS})

--- a/fmi4c/include/fmi4c.h
+++ b/fmi4c/include/fmi4c.h
@@ -17,6 +17,8 @@
 
 #ifdef _WIN32
 #include <direct.h>
+// Define WIN32_LEAN_AND_MEAN on the compilation commands to avoid any chance of someone including windows.h
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/fmi4c/src/fmi4c_private.h
+++ b/fmi4c/src/fmi4c_private.h
@@ -11,6 +11,8 @@
 
 #include <stdlib.h>
 #ifdef _WIN32
+    // Define WIN32_LEAN_AND_MEAN on the compilation commands to avoid any chance of someone including windows.h
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 #else
     #include <dlfcn.h>

--- a/minizip/src/CMakeLists.txt
+++ b/minizip/src/CMakeLists.txt
@@ -27,4 +27,4 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(minizip STATIC ${MINIZIP_SOURCES})
 
 install(TARGETS minizip DESTINATION lib/)
-install(FILES minizip.h miniunz.h DESTINATION include/)
+install(FILES minizip.h miniunz.h DESTINATION include/minizip)

--- a/minizip/src/CMakeLists.txt
+++ b/minizip/src/CMakeLists.txt
@@ -19,6 +19,10 @@ list(APPEND MINIZIP_SOURCES minizip.c)
 list(APPEND MINIZIP_SOURCES unzip.c)
 list(APPEND MINIZIP_SOURCES zip.c)
 
+if (WIN32)
+    list(APPEND MINIZIP_SOURCES iowin32.c)
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(minizip STATIC ${MINIZIP_SOURCES})
 


### PR DESCRIPTION
### Purpose

This PR integrates `fmi4c` library in `OMSimulator` and remove the use `FMILIB`

### Note

This PR also removes the internal dependencies of `fmi4c with minizip and zlib` and always uses the `minizip and zlib` from `OMSimulator 3rdParty` for easy maintenance.

Commit details:
https://github.com/OpenModelica/OMSimulator-3rdParty/commit/59fbebd36a24aca65bc1b379eae3fa6dd235a3bf
https://github.com/OpenModelica/OMSimulator-3rdParty/commit/a8d2aa192f255e5d098dc7b4569b9db951f9ee09
https://github.com/OpenModelica/OMSimulator-3rdParty/commit/31dbf55a8ad24c68288b5528d02b2371753a5dc8
