### PR TITLE
Adjust 3rdParty configuration to fit well with OpenModelica.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,36 @@
 #########################################################################
 ## Sundials
-option(SUNDIALS_BUILD_SHARED_LIBS "Build shared libraries" OFF)
-option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
-add_subdirectory(sundials-5.4.0 EXCLUDE_FROM_ALL)
+if(OMSIMULATOR_STANDALONE)
+  option(SUNDIALS_BUILD_SHARED_LIBS "Build shared libraries" OFF)
+  option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
+  add_subdirectory(sundials-5.4.0 EXCLUDE_FROM_ALL)
 
-## Sundials thoughtfully has organized its headers cleanly in one include/ directory
-## Take advantage of that to transitively provide the headers when an external target links to
-## any one of the sundials' libs.
-add_library(sundials_interface INTERFACE)
-target_include_directories(sundials_interface INTERFACE ${sundials_SOURCE_DIR}/include/)
-## The sundials_config.h files are generated in the build directory. Add it as an include dir.
-target_include_directories(sundials_interface INTERFACE ${sundials_BINARY_DIR}/include/)
+  ## Sundials thoughtfully has organized its headers cleanly in one include/ directory
+  ## Take advantage of that to transitively provide the headers when an external target links to
+  ## any one of the sundials' libs.
+  add_library(sundials_interface INTERFACE)
+  target_include_directories(sundials_interface INTERFACE ${sundials_SOURCE_DIR}/include/)
+  ## The sundials_config.h files are generated in the build directory. Add it as an include dir.
+  target_include_directories(sundials_interface INTERFACE ${sundials_BINARY_DIR}/include/)
 
-## Add an interface lib for linking ot the static libs. This will transitively add
-## DLINK_SUNDIALS_STATIC to anything that links to the static sundials libs.
-add_library(sundials_interface_static INTERFACE)
-target_link_libraries(sundials_interface_static INTERFACE sundials_interface)
-target_compile_definitions(sundials_interface_static INTERFACE LINK_SUNDIALS_STATIC)
+  ## Add an interface lib for linking ot the static libs. This will transitively add
+  ## DLINK_SUNDIALS_STATIC to anything that links to the static sundials libs.
+  add_library(sundials_interface_static INTERFACE)
+  target_link_libraries(sundials_interface_static INTERFACE sundials_interface)
+  target_compile_definitions(sundials_interface_static INTERFACE LINK_SUNDIALS_STATIC)
 
-## Now that the includes and defines are attached to a utility interface library (sundials_interface_static) link it
-## to the sundials static libs so they can be found when the sundials lib is linked-to from an external lib.
-### Note! It should have been enough for the scope here to be INTERFACE instead of PUBLIC. However,
-### that does not seem to work. This should be fine anyway.
-target_link_libraries(sundials_cvode_static PUBLIC sundials_interface_static)
-target_link_libraries(sundials_kinsol_static PUBLIC sundials_interface_static)
+  ## Now that the includes and defines are attached to a utility interface library (sundials_interface_static) link it
+  ## to the sundials static libs so they can be found when the sundials lib is linked-to from an external lib.
+  ### Note! It should have been enough for the scope here to be INTERFACE instead of PUBLIC. However,
+  ### that does not seem to work. This should be fine anyway.
+  target_link_libraries(sundials_cvode_static PUBLIC sundials_interface_static)
+  target_link_libraries(sundials_kinsol_static PUBLIC sundials_interface_static)
+endif()
 
 add_library(oms::3rd::cvode ALIAS sundials_cvode_static)
 add_library(oms::3rd::kinsol ALIAS sundials_kinsol_static)
+
+
 
 #########################################################################
 ## zlib.
@@ -37,7 +41,8 @@ add_library(oms::3rd::zlib ALIAS zlibstatic)
 #########################################################################
 ## minizip.
 add_subdirectory(minizip EXCLUDE_FROM_ALL)
-add_library(oms::3rd::minizip ALIAS minizip)
+add_library(oms::3rd::minizip ALIAS oms_minizip)
+
 
 #########################################################################
 ## fmi4c.

--- a/fmi4c/CMakeLists.txt
+++ b/fmi4c/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)
 target_include_directories(${target_name} PRIVATE src)
 target_link_libraries(${target_name} PUBLIC zlibstatic)
-target_link_libraries(${target_name} PUBLIC minizip)
+target_link_libraries(${target_name} PUBLIC oms_minizip)
 
 # Internal dependecy (PRIVATE) on zlib and ${CMAKE_DL_LIBS}) for libdl on Linux
 # target_link_libraries(${target_name} PRIVATE ZLIB::ZLIB ${CMAKE_DL_LIBS})

--- a/minizip/src/CMakeLists.txt
+++ b/minizip/src/CMakeLists.txt
@@ -1,32 +1,16 @@
 cmake_minimum_required(VERSION 2.8.9)
 project(minizip)
 
-IF(WIN32 AND MSVC)
-  set(PLATFORM_STRING "win")
-ELSEIF(WIN32 AND MINGW)
-  set(PLATFORM_STRING "mingw")
-ELSEIF(APPLE)
-  set(PLATFORM_STRING "mac")
-ELSE()
-  set(PLATFORM_STRING "linux")
-ENDIF()
-
-include_directories(../install/${PLATFORM_STRING}/include/)
-
-list(APPEND MINIZIP_SOURCES ioapi.c)
-list(APPEND MINIZIP_SOURCES miniunz.c)
-list(APPEND MINIZIP_SOURCES minizip.c)
-list(APPEND MINIZIP_SOURCES unzip.c)
-list(APPEND MINIZIP_SOURCES zip.c)
+set(MINIZIP_SOURCES ioapi.c
+                    miniunz.c
+                    minizip.c
+                    unzip.c
+                    zip.c)
 
 if (WIN32)
     list(APPEND MINIZIP_SOURCES iowin32.c)
 endif()
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-add_library(minizip STATIC ${MINIZIP_SOURCES})
+add_library(oms_minizip STATIC ${MINIZIP_SOURCES})
 
-target_include_directories(minizip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-install(TARGETS minizip)
-install(FILES minizip.h miniunz.h TYPE INCLUDE)
+target_include_directories(oms_minizip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
  - OMSimulator standalone has no issues and works just fine. However, we need to consider some things when it is being built as part of OpenModelica.

      - Sindials exists in OpenModelica's 3rdParty as well as OMSimulator's
        3rdParty. It creates the same named targets in both. This is not
        allowed. So if OMSimulator is part of OpenModelica (not standalone)
        skip adding its 3rdParty/Sundials and just use the targets already
        added by OpenModelica. Just create aliases for them.

      - FMIL continues to create issues as usual. This time from across
        the horizon. FMIL comes with `minizip `(among other things) and uses
        it in the usual contrived FMIL way. OMSimulator also comes with its
        own `minizip`. So, as a workaround, just rename OMSimulator's `minizip` to `oms_minizip`
        and use it with that name. It should be fine since it is only used
        locally and is not supposed to be installed anyway.