### PR TITLE
Use the CMake variable OPENMODELICA_NEW_CMAKE_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #########################################################################
 ## Sundials
-if(NOT OPENMODELICA_SUPERPROJECT)
+if(NOT OPENMODELICA_NEW_CMAKE_BUILD)
   option(SUNDIALS_BUILD_SHARED_LIBS "Build shared libraries" OFF)
   option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
   add_subdirectory(sundials-5.4.0 EXCLUDE_FROM_ALL)


### PR DESCRIPTION
 - This variable to signify that OMSimulator is being built as part of the OpenModelica CMake project. This was represented by the variable OPENMODELICA_SUPERPROJECT. However, as it turns out there is no need to add a new variable. It is also more descriptive because what we really want to know is that it is part of the OpenModelica CMake build and not just part of OpenModelica (as in the autoconf build).