### PR TITLE
fix xerces target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ add_library(oms::3rd::pugixml::header ALIAS pugixml_header_only)
 ## xerces
 option(XERCES_BUILD_SHARED_LIBS OFF)
 add_subdirectory(xerces EXCLUDE_FROM_ALL)
+### xerces does not include the target directories by default, so we have to externally add the include directories
+target_include_directories(xerces-c INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xerces/src)
+### Xerces_autoconf_config.hpp is generated at build directory and we have to include it
+target_include_directories(xerces-c INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/xerces/src)
 add_library(oms::3rd::xerces ALIAS xerces-c)
 
 #########################################################################

--- a/xerces/src/CMakeLists.txt
+++ b/xerces/src/CMakeLists.txt
@@ -1316,17 +1316,17 @@ else()
   set(xerces_config_dir "${CMAKE_INSTALL_LIBDIR}/cmake/XercesC")
 endif()
 
-install(TARGETS xerces-c
-  EXPORT XercesCConfigInternal
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  COMPONENT "runtime"
-  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-install(EXPORT XercesCConfigInternal
-        DESTINATION "${xerces_config_dir}"
-        NAMESPACE "xerces_"
-        COMPONENT "development")
+# install(TARGETS xerces-c
+#   EXPORT XercesCConfigInternal
+#   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+#   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#   COMPONENT "runtime"
+#   INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+# install(EXPORT XercesCConfigInternal
+#         DESTINATION "${xerces_config_dir}"
+#         NAMESPACE "xerces_"
+#         COMPONENT "development")
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(


### PR DESCRIPTION
### Purpose

This PR adds `target_include_directories` for xerces,  as xerces does not include the target directories by default.