### PR TITLE
Disable install() directives with non-needed components.

### DIFF
--- a/xerces/CMakeLists.txt
+++ b/xerces/CMakeLists.txt
@@ -165,10 +165,10 @@ set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
 set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/xerces-c.pc.in
                ${CMAKE_CURRENT_BINARY_DIR}/xerces-c.pc)
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/xerces-c.pc
-  DESTINATION "${PKGCONFIGDIR}"
-  COMPONENT "development")
+# install(
+#   FILES ${CMAKE_CURRENT_BINARY_DIR}/xerces-c.pc
+#   DESTINATION "${PKGCONFIGDIR}"
+#   COMPONENT "development")
 
 # Process subdirectories
 add_subdirectory(src)

--- a/xerces/src/CMakeLists.txt
+++ b/xerces/src/CMakeLists.txt
@@ -1341,13 +1341,13 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/XercesCConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/XercesCConfigVersion.cmake
               DESTINATION "${xerces_config_dir}")
 
-foreach(hdr IN LISTS libxerces_c_HEADERS)
-  get_filename_component(hdrdir "${hdr}" DIRECTORY)
-  install(
-    FILES "${hdr}"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${hdrdir}"
-    COMPONENT "development")
-endforeach()
+# foreach(hdr IN LISTS libxerces_c_HEADERS)
+#   get_filename_component(hdrdir "${hdr}" DIRECTORY)
+#   install(
+#     FILES "${hdr}"
+#     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${hdrdir}"
+#     COMPONENT "development")
+# endforeach()
 
 # Source file grouping (for IDE project layout)
 set(source_files ${libxerces_c_SOURCES} ${libxerces_c_HEADERS})
@@ -1373,8 +1373,8 @@ unset(group_files)
 
 # Make sure cmake-generated Xerces_autoconf_config.hpp and
 # XercesVersion.hpp end up in a proper place when installed.
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/xercesc/util/Xerces_autoconf_config.hpp"
-        "${CMAKE_CURRENT_BINARY_DIR}/xercesc/util/XercesVersion.hpp"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/xercesc/util"
-  COMPONENT "development")
+# install(
+#   FILES "${CMAKE_CURRENT_BINARY_DIR}/xercesc/util/Xerces_autoconf_config.hpp"
+#         "${CMAKE_CURRENT_BINARY_DIR}/xercesc/util/XercesVersion.hpp"
+#   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/xercesc/util"
+#   COMPONENT "development")


### PR DESCRIPTION
  - These install statements do not actually install anything because we have specified EXCLUDE_FROM_ALL when adding the xerces subdirectory in the CMakeLists file.

    Unfortunately, the install component they create (in this case called `development`) is added to the final list of install components. This causes a generation of an empty package named `development` when we use cpack to generate packages for OpenModelica.