### PR TITLE
free target memory if allocated in parseStringAttributeEzXml

### DIFF
--- a/fmi4c/src/fmi4c_utils.c
+++ b/fmi4c/src/fmi4c_utils.c
@@ -44,6 +44,9 @@ const char* getFunctionName(const char* modelName, const char* functionName, cha
 bool parseStringAttributeEzXml(ezxml_t element, const char *attributeName, const char **target)
 {
     if(ezxml_attr(element, attributeName)) {
+        if (*target) {
+            free((void*)*target);  // Free previous memory if allocated
+        }
         (*target) = _strdup(ezxml_attr(element, attributeName));
         return true;
     }


### PR DESCRIPTION
### Issues

https://github.com/robbr48/fmi4c/issues/63

### Purpose

check for previously allocated memory and free 