### PR TITLE
check for string data type when calculating initial attribute

### DIFF
--- a/fmi4c/src/fmi4c.c
+++ b/fmi4c/src/fmi4c.c
@@ -1729,6 +1729,7 @@ bool parseModelDescriptionFmi3(fmiHandle *fmu)
                var.datatype == fmi3DataTypeUInt16 ||
                var.datatype == fmi3DataTypeUInt8 ||
                var.datatype == fmi3DataTypeBoolean ||
+               var.datatype == fmi3DataTypeString ||
                var.datatype == fmi3DataTypeBinary ||
                var.datatype == fmi3DataTypeEnumeration) {
                const char* initial = NULL;


### PR DESCRIPTION
### Purpose

Check for String data type when calculating inital attribute for FMI 3.0