### PR TITLE
Fixes for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,16 @@ add_library(oms::3rd::kinsol ALIAS sundials_kinsol_static)
 #########################################################################
 ## zlib.
 message(STATUS "##### 3rdParty zlib")
-add_subdirectory(zlib EXCLUDE_FROM_ALL)
+option(OM_USE_SYSTEM_ZLIB "Use system zlib" OFF)
+if (OM_USE_SYSTEM_ZLIB)
+  set(ZLIB_USE_STATIC_LIBS ON)
+  find_package(ZLIB MODULE REQUIRED)
+  unset(ZLIB_USE_STATIC_LIBS)
+  add_library(zlibstatic INTERFACE)
+  target_link_libraries(zlibstatic INTERFACE ZLIB::ZLIB)
+else ()
+  add_subdirectory(zlib EXCLUDE_FROM_ALL)
+endif ()
 add_library(oms::3rd::zlib ALIAS zlibstatic)
 
 #########################################################################

--- a/fmi4c/src/fmi4c.c
+++ b/fmi4c/src/fmi4c.c
@@ -24,12 +24,18 @@
 #include <sys/stat.h>
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64)
-    #define arch_str "x86_64"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
     #define bits_str "64"
 #else
-    #define arch_str "x86"
     #define bits_str "32"
+#endif
+
+#if defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+    #define arch_str "aarch64"
+#elif defined(__x86_64__) || defined(_M_X64)
+    #define arch_str "x86_64"
+#else
+    #define arch_str "x86"
 #endif
 
 #if defined(__CYGWIN__)
@@ -44,6 +50,10 @@
     #define dllext_str ".dll"
     #define fmi12_system_str "win"
     #define fmi3_system_str "windows"
+#elif defined(__APPLE__)
+    #define dllext_str ".dylib"
+    #define fmi12_system_str "darwin"
+    #define fmi3_system_str "darwin"
 #else
     #define dllext_str ".so"
     #define fmi12_system_str "linux"


### PR DESCRIPTION
- Backports fmi4c/macos fix https://github.com/robbr48/fmi4c/pull/97
- Add an OM_USE_SYSTEM_ZLIB option so that we can switch to the system zlib (the bundled one does not build with error: stdio.h:210:7: error: expected identifier or '(')

I dont have write access here, so I hope some maintainer can merge it into a branch and update the submodule reference into the main repo

