### PR TITLE
Re-add xerces to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,16 @@ message(STATUS "##### 3rdParty PugiXml")
 add_subdirectory(PugiXml EXCLUDE_FROM_ALL)
 add_library(oms::3rd::pugixml::header ALIAS pugixml_header_only)
 
+#########################################################################
+## xerces
+message(STATUS "##### 3rdParty xerces")
+option(XERCES_BUILD_SHARED_LIBS OFF)
+add_subdirectory(xerces EXCLUDE_FROM_ALL)
+### xerces does not include the target directories by default, so we have to externally add the include directories
+target_include_directories(xerces-c INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xerces/src)
+### Xerces_autoconf_config.hpp is generated at build directory and we have to include it
+target_include_directories(xerces-c INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/xerces/src)
+add_library(oms::3rd::xerces ALIAS xerces-c)
 
 #########################################################################
 ## CTPL.


### PR DESCRIPTION
Xerces was previously removed from CMakeLists.txt, but it is needed by DCPLib.