### PR TITLE
Disable shared zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(oms::3rd::kinsol ALIAS sundials_kinsol_static)
 #########################################################################
 ## zlib.
 message(STATUS "##### 3rdParty zlib")
+# Disable shared build to avoid target name conflict with OMCompiler/3rdParty/zlib
+set(ZLIB_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 add_subdirectory(zlib EXCLUDE_FROM_ALL)
 add_library(oms::3rd::zlib ALIAS zlibstatic)
 


### PR DESCRIPTION
## Issue

For https://github.com/OpenModelica/OpenModelica/pull/15464.

```
CMake Error at OMSimulator/3rdParty/zlib/CMakeLists.txt:158 (add_library):
  add_library cannot create target "zlib" because another target with the
  same name already exists.  The existing target is a static library created
  in source directory
  "/var/lib/jenkins1/ws/OpenModelica_PR-15464/OMCompiler/3rdParty/zlib".  See
  documentation for policy CMP0002 for more details.
```



## Changes

* OMSimulator only uses static version of zlib